### PR TITLE
ci: auto-create GitHub Release on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- add a tag-triggered workflow to auto-create GitHub Releases
- trigger on pushed tags matching `v*`
- use `softprops/action-gh-release@v2` with generated release notes

## Files Changed
- `.github/workflows/release.yml`

Closes #13
